### PR TITLE
プロトタイプ編集機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  before_action :authenticate_user!, except: [:index, :show]
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :basic_auth
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,6 @@
 class PrototypesController < ApplicationController
+  before_action :correct_user, only: [:edit, :update]
+
   def index
     @prototypes = Prototype.includes(:user)
   end
@@ -20,9 +22,29 @@ class PrototypesController < ApplicationController
     @prototype = Prototype.find(params[:id])
   end
 
+  def edit
+    @prototype = Prototype.find(params[:id])
+  end
+
+  def update
+    @prototype = Prototype.find(params[:id])
+    if @prototype.update(prototype_params)
+      redirect_to action: :show
+    else
+      render :edit
+    end
+  end
+
   private
 
   def prototype_params
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
+  end
+
+  def correct_user
+    prototype = Prototype.find(params[:id])
+    if current_user.id != prototype.user_id
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,5 @@
 class PrototypesController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :correct_user, only: [:edit, :update]
 
   def index

--- a/app/views/prototypes/edit.html.erb
+++ b/app/views/prototypes/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="form__wrapper">
       <h2 class="page-heading">プロトタイプ編集</h2>
-      <%# 部分テンプレートでフォームを表示する %>
+        <%= render partial: 'form', locals: { prototype: @prototype } %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# What
プロトタイプ編集機能の実装

# Why
プロトタイプ編集機能を実装するため


ログイン状態の投稿者は、プロトタイプ情報編集ページに遷移できる動画
https://gyazo.com/f475911c43a06b5512517d4508d8b7a8
必要な情報を適切に入力して「保存する」ボタンを押すと、プロトタイプの情報を編集できる動画
https://gyazo.com/9e2d235f592767c97f740b63f272f116
https://gyazo.com/dc56438cda39318b1c612c66ecd6b51d
入力に問題がある状態で「保存する」ボタンが押された場合、情報は保存されず、そのページに留まる動画
https://gyazo.com/e653df4fccc4fcf0434f7333e5146ad9
何も編集せずに「保存する」ボタンを押しても、画像無しのプロトタイプにならない動画
https://gyazo.com/1b42b8dc4c010de506c0924dd1f45511
ログイン状態の場合でも、URLを直接入力して自身が投稿していないプロトタイプのプロトタイプ情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/e34549e9cdbaccc182f1fe45a50a5cd0
ログアウト状態の場合は、URLを直接入力してプロトタイプ情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/0a65bd6643012ffc0b7935602ab5c7d9
プロトタイプ情報について、すでに登録されている情報は、編集画面を開いた時点で表示される動画
https://gyazo.com/c08d73f69b7b16801a96b65d903b6166