### PR TITLE
update,destroyの両アクションに、set_prototypeビフォアアクションを設定

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,7 +1,7 @@
 class PrototypesController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :correct_user, only: [:edit, :update]
-  before_action :set_prototype, only: [:edit, :show]
+  before_action :set_prototype, only: [:edit, :show, :update, :destroy]
   
   def index
     @prototypes = Prototype.includes(:user)
@@ -26,7 +26,6 @@ class PrototypesController < ApplicationController
   end
 
   def update
-    @prototype = Prototype.find(params[:id])
     if @prototype.update(prototype_params)
       redirect_to action: :show
     else
@@ -35,7 +34,6 @@ class PrototypesController < ApplicationController
   end
 
   def destroy
-    @prototype = Prototype.find(params[:id])
     if @prototype.destroy
       redirect_to root_path
     end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,6 @@
 class PrototypesController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_prototype, only: [:edit, :show, :update, :destroy, :correct_user]
+  before_action :set_prototype, only: [:edit, :show, :update, :destroy]
   before_action :correct_user, only: [:edit, :update]
   
   def index

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,7 +1,7 @@
 class PrototypesController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_prototype, only: [:edit, :show, :update, :destroy, :correct_user]
   before_action :correct_user, only: [:edit, :update]
-  before_action :set_prototype, only: [:edit, :show, :update, :destroy]
   
   def index
     @prototypes = Prototype.includes(:user)
@@ -50,8 +50,7 @@ class PrototypesController < ApplicationController
   end
 
   def correct_user
-    prototype = Prototype.find(params[:id])
-    if current_user.id != prototype.user_id
+    if current_user.id != @prototype.user_id
       redirect_to root_path
     end
   end


### PR DESCRIPTION
# What
update,destroyの両アクションに、set_prototypeビフォアアクションを設定

# Why
Railsの基本理念であるDRYに従い、コードの可読性を高めるため。