### PR TITLE
createアクション前にauthenticate_user!を追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,6 @@
 class CommentsController < ApplicationController
+  before_action :authenticate_user!, only: [:create]
+  
   def create
     comment = Comment.create(comment_params)
     redirect_to "/prototypes/#{comment.prototype.id}"


### PR DESCRIPTION
# What
createアクション前にauthenticate_user!を追加

# Why
ログインしているユーザーのみ、コメント登録を行えるように制御するため