### PR TITLE
Aws s3に画像を保存して、herokuへ投稿した画像のリンク切れを解消する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,4 @@ gem 'pry-rails'
 gem 'devise'
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
+gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,22 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.504.0)
+    aws-sdk-core (3.121.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.48.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.103.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.4.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.8.1)
@@ -102,6 +118,7 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    jmespath (1.4.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -269,13 +286,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
   devise
-  image_processing (~> 1.2)
   factory_bot_rails
   faker
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   mini_magick

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,11 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+amazon:
+ service: S3
+ region: ap-northeast-1
+ bucket: protospace-fukui2021-club-dino-heroku-images
+
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -10,6 +10,8 @@ amazon:
  service: S3
  region: ap-northeast-1
  bucket: protospace-fukui2021-club-dino-heroku-images
+ access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+ secret_access_key:  <%= ENV['AWS_SECRET_ACCESS_KEY'] %> 
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
# What
Aws s3に画像を保存して、herokuへ投稿した画像のリンク切れを解消する

# Why
追加実装　リンク切れを解決するため

※AWSとVScodeはカリキュラム通りに登録しているのでコードレビューまで必要ないかもしれませんが・・・。

１）ローカル環境上では実装済み
- prototypeの画像を投稿し、S3に同じ画像データが保存されるか確認する（確認済み）
- prototypeを削除し、S3に保存されている画像データも削除されているか確認する（確認済み）

２）本番環境Heroku上では未実装
（マージしてローカルのMasterから更新し、その後Herokuの設定をしなければいけないため）

- prototypeの画像を投稿し、リンク切れが解決するか確認する
（※現状の本番環境では、デプロイ作業 or 24時間経過後サーバーリセットによるリンク削除が実施されてしまう）
- prototypeを削除したらS3でも削除されているか確認する

動画：ローカル環境(http://localhost:3000)でプロトタイプを投稿して、S3にも同様に画像が保存されている様子

https://user-images.githubusercontent.com/90016212/134459445-c0f6dce3-90c3-4729-92d0-7eb2f0414a07.mp4


