### PR TITLE
画像のプレビュー機能

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,10 +4,10 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
-
+require("../preview.js")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -8,6 +8,12 @@ function previewImage() {
 
     // プロトタイプの画像変更時の処理
     document.getElementById('prototype_image').addEventListener('change', function(e){
+      // 画像が表示されている場合のみ、すでに存在している画像を削除する
+      const imageContent = document.querySelector('img');
+      if (imageContent) {
+        imageContent.remove();
+      }
+      
       const file = e.target.files[0]
       const blob = window.URL.createObjectURL(file)
 

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -7,28 +7,27 @@ function previewImage() {
     const imagePreview = document.getElementById('prototype_image_preview')
 
     // プロトタイプの画像変更時の処理
-    prototype_image.addEventListener('change', function(e){
-      
-      // プロトタイプの画像が表示されている場合のみ、すでに存在している画像を削除する
-      const imageContent = document.getElementById("image_content");
+    document.getElementById('prototype_image').addEventListener('change', function(e){
+      // 画像が表示されている場合のみ、すでに存在している画像を削除する
+      const imageContent = document.querySelector('img');
       if (imageContent) {
         imageContent.remove();
       }
       
-      // 画像表示領域の要素を取得
-      const image_section = document.getElementById('image_section')
-      // ファイル情報を取得
       const file = e.target.files[0]
-      // ファイルのURLを作成
       const blob = window.URL.createObjectURL(file)
+
+      // 画像を表示するためのdiv要素を生成
+      const imageElement = document.createElement('div')
 
       // 表示する画像を生成
       const blobImage = document.createElement('img')
-      blobImage.setAttribute('id', 'image_content')
       blobImage.setAttribute('src', blob)
 
       // 生成したHTMLの要素をブラウザに表示させる
-      image_section.appendChild(blobImage)
+      imageElement.appendChild(blobImage)
+      imagePreview.appendChild(imageElement)
     })
   }
 }
+

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -3,31 +3,34 @@ document.addEventListener('DOMContentLoaded', function(){
 })
 
 function previewImage() {
-  if (document.getElementById('prototype_image_preview')){
-    const imagePreview = document.getElementById('prototype_image_preview')
+  const prototype_image = document.getElementById('prototype_image')
+
+  // プロトタイプの画像選択フィールドがある場合のみ、以下処理を行う
+  if (prototype_image){
 
     // プロトタイプの画像変更時の処理
-    document.getElementById('prototype_image').addEventListener('change', function(e){
-      // 画像が表示されている場合のみ、すでに存在している画像を削除する
-      const imageContent = document.querySelector('img');
+    prototype_image.addEventListener('change', function(e){
+      
+      // プロトタイプの画像が表示されている場合のみ、すでに存在している画像を削除する
+      const imageContent = document.getElementById("image_content");
       if (imageContent) {
         imageContent.remove();
       }
       
+      // 画像表示領域の要素を取得
+      const image_section = document.getElementById('image_section')
+      // ファイル情報を取得
       const file = e.target.files[0]
+      // ファイルのURLを作成
       const blob = window.URL.createObjectURL(file)
-
-      // 画像を表示するためのdiv要素を生成
-      const imageElement = document.createElement('div')
 
       // 表示する画像を生成
       const blobImage = document.createElement('img')
+      blobImage.setAttribute('id', 'image_content')
       blobImage.setAttribute('src', blob)
 
       // 生成したHTMLの要素をブラウザに表示させる
-      imageElement.appendChild(blobImage)
-      imagePreview.appendChild(imageElement)
+      image_section.appendChild(blobImage)
     })
   }
 }
-

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', function(){
+  previewImage()
+})
+
+function previewImage() {
+  if (document.getElementById('prototype_image_preview')){
+    const imagePreview = document.getElementById('prototype_image_preview')
+
+    // プロトタイプの画像変更時の処理
+    document.getElementById('prototype_image').addEventListener('change', function(e){
+      const file = e.target.files[0]
+      const blob = window.URL.createObjectURL(file)
+
+      // 画像を表示するためのdiv要素を生成
+      const imageElement = document.createElement('div')
+
+      // 表示する画像を生成
+      const blobImage = document.createElement('img')
+      blobImage.setAttribute('src', blob)
+
+      // 生成したHTMLの要素をブラウザに表示させる
+      imageElement.appendChild(blobImage)
+      imagePreview.appendChild(imageElement)
+    })
+  }
+}
+

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -7,27 +7,28 @@ function previewImage() {
     const imagePreview = document.getElementById('prototype_image_preview')
 
     // プロトタイプの画像変更時の処理
-    document.getElementById('prototype_image').addEventListener('change', function(e){
-      // 画像が表示されている場合のみ、すでに存在している画像を削除する
-      const imageContent = document.querySelector('img');
+    prototype_image.addEventListener('change', function(e){
+      
+      // プロトタイプの画像が表示されている場合のみ、すでに存在している画像を削除する
+      const imageContent = document.getElementById("image_content");
       if (imageContent) {
         imageContent.remove();
       }
       
+      // 画像表示領域の要素を取得
+      const image_section = document.getElementById('image_section')
+      // ファイル情報を取得
       const file = e.target.files[0]
+      // ファイルのURLを作成
       const blob = window.URL.createObjectURL(file)
-
-      // 画像を表示するためのdiv要素を生成
-      const imageElement = document.createElement('div')
 
       // 表示する画像を生成
       const blobImage = document.createElement('img')
+      blobImage.setAttribute('id', 'image_content')
       blobImage.setAttribute('src', blob)
 
       // 生成したHTMLの要素をブラウザに表示させる
-      imageElement.appendChild(blobImage)
-      imagePreview.appendChild(imageElement)
+      image_section.appendChild(blobImage)
     })
   }
 }
-

--- a/app/views/prototypes/_form.html.erb
+++ b/app/views/prototypes/_form.html.erb
@@ -18,10 +18,7 @@
   <div class="field">
     <%= f.label :image, "プロトタイプの画像" %><br />
     <%= f.file_field :image, id:"prototype_image" %>
-    <div id="image_section" class="prototype__image">
-      <% if !prototype.image.blank? %>
-        <%= image_tag prototype.image, id:"image_content"%>
-      <% end %>
+    <div id = "prototype_image_preview" class="prototype__image">
     </div>
   </div>
 

--- a/app/views/prototypes/_form.html.erb
+++ b/app/views/prototypes/_form.html.erb
@@ -18,6 +18,8 @@
   <div class="field">
     <%= f.label :image, "プロトタイプの画像" %><br />
     <%= f.file_field :image, id:"prototype_image" %>
+    <div id = "prototype_image_preview" class="prototype__image">
+    </div>
   </div>
 
   <div class="actions">

--- a/app/views/prototypes/_form.html.erb
+++ b/app/views/prototypes/_form.html.erb
@@ -18,7 +18,10 @@
   <div class="field">
     <%= f.label :image, "プロトタイプの画像" %><br />
     <%= f.file_field :image, id:"prototype_image" %>
-    <div id = "prototype_image_preview" class="prototype__image">
+    <div id="image_section" class="prototype__image">
+      <% if !prototype.image.blank? %>
+        <%= image_tag prototype.image, id:"image_content"%>
+      <% end %>
     </div>
   </div>
 


### PR DESCRIPTION
# What
画像のプレビュー機能の追加

# Why
新規投稿、編集時に選択した画像をプレビューするため


- 新規プロトタイプ投稿画面で画像選択時に、画像がプレビューされるように実装する
https://gyazo.com/d55a1c4fd5d6eb1e8dff30f9d2bbcb70


- 新規プロトタイプ投稿画面ですでに画像が選択されている場合、画像選択した場合に元の画像が削除され、新しく選択した画像がプレビューされるように実装する
https://gyazo.com/b942d16f5416228494bb90660af64c9e


- プロトタイプ編集画面の表示時に、画像がプレビューされるように実装する
https://gyazo.com/cb30589e1be8cf0c32e3645641f83f81


- プロトタイプ編集画面の表示時に、画像選択した場合に元の画像が削除され、新しく選択した画像がプレビューされるように実装する
https://gyazo.com/a641371f35def9f8bccb543e2b6f2d1a
