### PR TITLE
住所情報登録ページの日本語化対応

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,11 @@ ja:
         profile: プロフィール
         occupation: 所属 
         position: 役職
+      address:
+        postal_code: 郵便番号
+        address: 住所
+    models:
+      address: 住所情報
       prototype:
         title: プロトタイプの名称
         catch_copy: キャッチコピー


### PR DESCRIPTION
# What
エラーメッセージ日本語化、住所登録ページ対応

# Why
エラー文をユーザーに読みやすくするため

住所情報登録ページで空のまま新規登録しようとしたとき↓
https://gyazo.com/57f98bf94d73758c03767f0c81c05e05