### PR TITLE
EC2のログイン設定を追加し、Herokuのデプロイ記述をコメントアウト

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -47,8 +47,18 @@ test:
 #   production:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
+
+# Herokuのデプロイ時に使用する(※AWS-EC2側はコメントアウトしておくこと)
+# production:
+  # <<: *default
+  # database: protospace_fukui2021_Club_Dinosaur_production
+  # username: protospace_fukui2021_Club_Dinosaur
+  # password: <%= ENV['PROTOSPACE_FUKUI2021_CLUB_DINOSAUR_DATABASE_PASSWORD'] %>
+
+# AWS-EC2のデプロイ時に使用する(※Heroku側はコメントアウトしておくこと)
 production:
   <<: *default
   database: protospace_fukui2021_Club_Dinosaur_production
-  username: protospace_fukui2021_Club_Dinosaur
-  password: <%= ENV['PROTOSPACE_FUKUI2021_CLUB_DINOSAUR_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
# What
EC2のログイン設定を追加

# Why
EC2のサーバーを立ち上げるため

※テキスト通りの為、レビューは不要です。
