### PR TITLE
本番環境のBasic認証の一時的無効化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :basic_auth
+  # before_action :basic_auth
 
   private
 
@@ -8,11 +8,11 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :profile, :occupation, :position])
   end
 
-  def basic_auth
-    if Rails.env.production?
-      authenticate_or_request_with_http_basic do |username, password|
-        username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']  # 環境変数を読み込む記述に変更
-      end
-    end
-  end
-end
+  # def basic_auth
+    # if Rails.env.production?
+      # authenticate_or_request_with_http_basic do |username, password|
+        # username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']  # 環境変数を読み込む記述に変更
+      # end
+    # end
+  # end
+# end


### PR DESCRIPTION
# What
本番環境のBasic認証の一時的無効化

# Why
Webページ確認より先に認証確認が行われるので、一時的に解除する

※レビューは不要です。
