### PR TITLE
日本語化ファイル修正

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,7 @@
 ja:
   activerecord:
+    models:
+      address: 住所情報
     attributes:
       user:
         name: ユーザー名
@@ -9,8 +11,6 @@ ja:
       address:
         postal_code: 郵便番号
         address: 住所
-    models:
-      address: 住所情報
       prototype:
         title: プロトタイプの名称
         catch_copy: キャッチコピー


### PR DESCRIPTION
# What
スプリントレビューでうまく表示されなかったところの修正

# Why
ちゃんとビューを表示させるため

↓new,editアクションのエラーメッセージ
https://gyazo.com/b56221a916bac40802efe8a72de91c9b
https://gyazo.com/cf71cd7a58bf44a93c30e789e7128320

addressビュー対応のため追加した、
`models:
   address: 住所情報`
の配置する位置が問題でした。
郵便番号、住所の後に配置したんですが間違いだったようです。だから、ユーザー登録のエラーメッセージがちゃんと表示されて、それ以降のプロトタイプ関連のビューが表示されなかったようです。
修正後、すべてのエラーメッセージが表示されることも確認しました。お騒がせしました。